### PR TITLE
feat: change display-name if noita can not display

### DIFF
--- a/lib/noita.js
+++ b/lib/noita.js
@@ -162,9 +162,10 @@ class Noita {
 
     init() {
         this.twitch.client.on("message", (ch, userstate, message, self) => {
+            const displayableName = this.twitch.getDisplayableName(userstate)
             if (self) return
-            if (this.voters.indexOf(userstate['display-name']) === -1) {
-                this.voters.push(`"${userstate['display-name']}"`)
+            if (this.voters.indexOf(displayableName) === -1) {
+                this.voters.push(`"${displayableName}"`)
             }
             this.handleVote(userstate['user-id'], message)
         })

--- a/lib/twitch.js
+++ b/lib/twitch.js
@@ -45,7 +45,7 @@ class Twitch {
                 let msg = this.interpolate(
                     this.settings["highlighted-message"].func,
                     {
-                        name: userstate["display-name"],
+                        name: getDisplayableName(userstate),
                         message: message.replace(/"|'/g, "")
                     })
                 noita.toGame(msg)
@@ -70,7 +70,7 @@ class Twitch {
         //bits
         this.client.on("cheer", (ch, userstate, message) => {
             let bits = userstate.bits
-            console.log(`${userstate["display-name"]} threw ${bits} bits.`)
+            console.log(`${getDisplayableName(userstate)} threw ${bits} bits.`)
         })
 
         //subs
@@ -111,7 +111,7 @@ class Twitch {
     customReward(id, userstate, message) {
         let reward = this.settings["custom-rewards"][id]
         if (!reward) {
-            console.log(`Unknown reward id: "${id}", message: ${userstate["display-name"]}: ${message}`)
+            console.log(`Unknown reward id: "${id}", message: ${getDisplayableName(userstate)}: ${message}`)
             return
         }
 
@@ -121,7 +121,7 @@ class Twitch {
         let func = this.interpolate(
             reward.func,
             {
-                name: userstate["display-name"],
+                name: getDisplayableName(userstate),
                 message: message.replace(/"|'/g, "")
             })
         if (this.settings.show_user_msg) {
@@ -181,6 +181,15 @@ class Twitch {
             const objPath = match.slice(2, -1).trim();
             return this.getObjPath(objPath, variables, fallback);
         })
+    }
+
+    getDisplayableName(userstate) {
+        const displayable = !/[^#$%&=@()!?_<>\[\]A-Z0-9a-z]/.test(userstate["display-name"])
+        if (displayable) {
+            return userstate["display-name"]
+        } else {
+            return userstate["username"]
+        }
     }
 }
 


### PR DESCRIPTION
# What is this?

Noita's SpriteComponent can not show CJK charactors(displayed as “??????”).
So I changed display-name to username, when display-name can not display in noita.

# Evidence

Only checked characters are used as regex patterns.

![20220225004444_1](https://user-images.githubusercontent.com/96275684/155563361-abc6c4c8-8047-4cf5-8484-d0d786557003.jpg)

