### PR TITLE
Balance Patch #2

### DIFF
--- a/files/entities/animals/blackhole_boomerang.xml
+++ b/files/entities/animals/blackhole_boomerang.xml
@@ -247,7 +247,7 @@
 	_enabled="1" 
 	hunt_box_radius="512" 
 	new_hunt_target_check_every="60" 
-	speed="30" 
+	speed="27" 
 	velocity.x="-0.37877" 
 	velocity.y="-0.307411"
 	target_tag="player_unit"

--- a/files/entities/misc/effect_hex_water.xml
+++ b/files/entities/misc/effect_hex_water.xml
@@ -18,12 +18,15 @@
 		>
 	</LuaComponent>
 
+	
+	<!-- This lua script handles stain damage
 	<LuaComponent
 		execute_on_added="0"
 		script_source_file="mods/Twitch-integration/files/scripts/hex_water_persistent.lua"
 		execute_every_n_frame="3"
 		>
 	</LuaComponent>
+	-->
 	
 	<LifetimeComponent
 		lifetime="1800"

--- a/files/entities/misc/effect_steal_wand.xml
+++ b/files/entities/misc/effect_steal_wand.xml
@@ -31,11 +31,13 @@
 		execute_every_n_frame="70"
 		>
 	</LuaComponent>
-	
-	<AudioComponent
+
+	<AudioLoopComponent
 		file="data/audio/Desktop/misc.bank"
-		event_root="game_effect/blindness" >
-	</AudioComponent>
+		event_name="game_effect/blindness/create"
+		set_speed_parameter="1"
+		auto_play="1">
+	</AudioLoopComponent>
 	
 	
 </Entity>

--- a/files/scripts/effect_blackhole_boomerang_rubberband.lua
+++ b/files/scripts/effect_blackhole_boomerang_rubberband.lua
@@ -4,7 +4,7 @@ local pos_x, pos_y = EntityGetTransform(entity_id)
 local comp = EntityGetFirstComponentIncludingDisabled(entity_id,"GhostComponent")
 
 if #EntityGetInRadiusWithTag(pos_x, pos_y, 200, "player_unit") <= 0 then
-    ComponentSetValue2(comp,"speed",90)
+    ComponentSetValue2(comp,"speed",60)
 else
-    ComponentSetValue2(comp,"speed",40)
+    ComponentSetValue2(comp,"speed",30)
 end

--- a/files/scripts/effect_blackhole_boomerang_rubberband.lua
+++ b/files/scripts/effect_blackhole_boomerang_rubberband.lua
@@ -6,5 +6,5 @@ local comp = EntityGetFirstComponentIncludingDisabled(entity_id,"GhostComponent"
 if #EntityGetInRadiusWithTag(pos_x, pos_y, 200, "player_unit") <= 0 then
     ComponentSetValue2(comp,"speed",60)
 else
-    ComponentSetValue2(comp,"speed",30)
+    ComponentSetValue2(comp,"speed",27)
 end

--- a/files/scripts/hex_water_persistent.lua
+++ b/files/scripts/hex_water_persistent.lua
@@ -3,5 +3,5 @@ entity_id = EntityGetRootEntity(entity_id)
 
 local effectTest = GameGetGameEffectCount( entity_id, "WET" )
 if effectTest >= 1 then
-     EntityInflictDamage( entity_id, 0.020, "DAMAGE_CURSE", "Abyssal Hex", "NONE", 0, 0, 0 )
+     EntityInflictDamage( entity_id, 0.004, "DAMAGE_CURSE", "Abyssal Hex", "NONE", 0, 0, 0 )
 end

--- a/files/scripts/hex_water_start.lua
+++ b/files/scripts/hex_water_start.lua
@@ -16,7 +16,7 @@ if comp ~= 0 then
     }
 
     for k=1,#materials do
-        EntitySetDamageFromMaterial( entity_id, materials[k], 0.001)
+        EntitySetDamageFromMaterial( entity_id, materials[k], 0.0003)
     end
 
 end

--- a/twitch_fragments/outcomes/conga_monstrous_drink.lua
+++ b/twitch_fragments/outcomes/conga_monstrous_drink.lua
@@ -6,7 +6,17 @@
 function twitch_conga_monstrous_drink()
     local inventory = GetInven()
     local items = EntityGetAllChildren(inventory)
+    local potiontable = {}
+    SetRandomSeed( GameGetFrameNum(), GameGetFrameNum() + 8 )
     if items ~= nil then
-        AddMaterialInventoryMaterial(items[1], "monster_powder_test", 10)
+        for k=1,#items
+        do v = items[k]
+            if EntityHasTag(v,"potion") == true then
+                table.insert(potiontable,v)
+            end
+        end
+        if #potiontable >= 1 then
+            AddMaterialInventoryMaterial(potiontable[Random(1,#potiontable)], "monster_powder_test", 10)
+        end
     end
 end

--- a/twitch_fragments/outcomes/conga_steal_wand.lua
+++ b/twitch_fragments/outcomes/conga_steal_wand.lua
@@ -10,7 +10,7 @@ function twitch_conga_steal_wand()
         local x,y = EntityGetTransform(player)
         local c = EntityLoad("mods/Twitch-integration/files/entities/misc/effect_steal_wand.xml",x,y)
         EntityAddChild(v,c)
-        GamePlaySound( "data/audio/Desktop/misc.bank", "game_effect/blindness/create", x, y );
+        GamePlaySound( "data/audio/Desktop/misc.bank", "game_effect/blindness/create",x,y)
     end
 end
 


### PR DESCRIPTION
Poisoned Water no longer does stain damage, you're allowed to extinguish yourself now
Poisoned Water does 70% less damage on material contact
Homing Blackhole's rubberband effect is now 33% slower, giving you more time to teleport away before it catches back up
Fixed Possess Wand not properly playing an audio que
Fixed Homing Blackhole not having a speed reduction (Hey, you were dodging it pre-nerf!     good job god gamer old man!)

Further reduced Homing Blackhole Speed by 10% (30 to 27)
Fixed Monstrous Drink not properly adding monstrous powder to the player's potion (Thankyou Miczu for pointing this out!)